### PR TITLE
mouse-less copying and global shortcut

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,22 +1,27 @@
 let chars = document.getElementsByClassName('char');
+let shortcuts = {}
+for (item of chars){
+    shortcuts[item.getAttribute("key-shortcut")] = item
+}
 let copiedAlert = document.getElementById('copiedAlert');
 
 async function timeout(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 };
 
+async function copy(text) {
+    let textarea = document.createElement('textarea');
+    textarea.select();
+    textarea.setSelectionRange(0, 99999);
+    navigator.clipboard.writeText(text);
+    document.body.appendChild(textarea);
+    textarea.remove();
+
+}
+
 for (i=0; i<chars.length; i++) {
         chars[i].addEventListener('click', async (e) => {
-            let textarea = document.createElement('textarea');
-            textarea.value = e.target.innerText;
-            document.body.appendChild(textarea);
-            textarea.select();
-            textarea.setSelectionRange(0, 99999);
-            navigator.clipboard.writeText(textarea.value);
-            textarea.remove();
-            /* copiedAlert.classList.remove('hidden');
-            await timeout(700);
-            copiedAlert.classList.add('hidden'); */
+            copy(e.target.innerText);
         });
 }
 
@@ -25,6 +30,9 @@ document.addEventListener('keydown', async (e) => {
         for (i=0; i<chars.length; i++) {
             chars[i].children[0].innerText = chars[i].children[0].innerText.toUpperCase();
         }
+    }
+    if(e.key.toLowerCase() in shortcuts){
+        copy(shortcuts[e.key.toLowerCase()].innerText);
     }
 });
 

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, globalShortcut } = require('electron');
 const path = require('path');
 let win;
 
@@ -25,6 +25,14 @@ app.whenReady().then(() => {
     app.on('activate', () => {
         if (BrowserWindow.getAllWindows().length === 0) createWindow();
     });
+
+  const ret = globalShortcut.register('Ctrl+alt+.', () => {
+    if(win.isFocused()){
+        win.hide()
+    }else{
+        win.show()
+    }
+  })
 });
 
 app.on('window-all-closed', () => {
@@ -50,3 +58,8 @@ ipcMain.on('options-action', function (event, arg) {
             break;
     }
 });
+
+
+app.on('will-quit', () => {
+    globalShortcut.unregisterAll()
+  })

--- a/views/index.html
+++ b/views/index.html
@@ -39,19 +39,19 @@
             <h2><span>copied!</span></h2>
         </div>
         <div class="chars">
-            <div class="char">
+            <div class="char" key-shortcut="a">
                 <a>á</a>
             </div>
-            <div class="char">
+            <div class="char" key-shortcut="e">
                 <a>é</a>
             </div>
-            <div class="char">
+            <div class="char" key-shortcut="i">
                 <a>í</a>
             </div>
-            <div class="char">
+            <div class="char" key-shortcut="o">
                 <a>ó</a>
             </div>
-            <div class="char">
+            <div class="char" key-shortcut="u">
                 <a>ú</a>
             </div>
         </div>


### PR DESCRIPTION
this pr adds a global shortcut (ctrl + alt+ .) to show/hide the app and enables copying the missing char by typing on the keyboard while the app is focused (typing e with the app focused will type è, also works while holding shift for caps)